### PR TITLE
Move VERSION to a seperate file.

### DIFF
--- a/lib/waveform.rb
+++ b/lib/waveform.rb
@@ -8,7 +8,6 @@ rescue LoadError
 end
 
 class Waveform
-  VERSION = "0.0.3"
   
   DefaultOptions = {
     :method => :peak,

--- a/lib/waveform/version.rb
+++ b/lib/waveform/version.rb
@@ -1,0 +1,3 @@
+class Waveform
+  VERSION = "0.0.3"
+end

--- a/waveform.gemspec
+++ b/waveform.gemspec
@@ -1,4 +1,4 @@
-require "./lib/waveform"
+require "./lib/waveform/version"
 
 Gem::Specification.new do |s|
   s.name              = "waveform"


### PR DESCRIPTION
This allows bundler to evaluate gem dependencies without needing to load `ruby-audio`.

Basically before this patch, it's impossible to use waveform with bundler's `git:` option
